### PR TITLE
Update channel name, slug, and query

### DIFF
--- a/lib/contracts/channel-user-feedback.ts
+++ b/lib/contracts/channel-user-feedback.ts
@@ -1,13 +1,13 @@
 import type { ContractDefinition } from 'autumndb';
 
-export const channelFeedback: ContractDefinition = {
-	slug: 'channel-feedback',
-	name: 'Feedback',
+export const channelUserFeedback: ContractDefinition = {
+	slug: 'channel-user-feedback',
+	name: 'User Feedback',
 	type: 'channel@1.0.0',
 	markers: ['org-balena'],
 	data: {
 		filter: {
-			name: 'Feedback contracts',
+			name: 'User feedback contracts',
 			schema: {
 				type: 'object',
 				additionalProperties: true,
@@ -15,7 +15,7 @@ export const channelFeedback: ContractDefinition = {
 				properties: {
 					type: {
 						type: 'string',
-						const: 'typeform-feedback@1.0.0',
+						enum: ['user-feedback@1.0.0', 'typeform-feedback@1.0.0'],
 					},
 				},
 			},

--- a/lib/contracts/index.ts
+++ b/lib/contracts/index.ts
@@ -1,11 +1,11 @@
 import type { ContractDefinition } from 'autumndb';
-import { channelFeedback } from './channel-feedback';
+import { channelUserFeedback } from './channel-user-feedback';
 import { relationshipPatternIsAttachedToTypeformFeedback } from './relationship-pattern-is-attached-to-typeform-feedback';
 import { relationshipTypeformFeedbackIsOwnedByUser } from './relationship-typeform-feedback-is-owned-by-user';
 import { typeformFeedback } from './typeform-feedback';
 
 export const contracts: ContractDefinition[] = [
-	channelFeedback,
+	channelUserFeedback,
 	relationshipPatternIsAttachedToTypeformFeedback,
 	relationshipTypeformFeedbackIsOwnedByUser,
 	typeformFeedback,

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "lint:fix": "balena-lint --fix lib test && prettier -w **/*.json **/*.yml",
     "test": "npm run lint && npm run test:unit",
     "test:unit": "jest test/unit",
-    "test:integration": "jest --bail --runInBand test/integration",
+    "test:integration": "jest --runInBand --bail --forceExit test/integration",
     "doc": "typedoc lib/ && touch docs/.nojekyll",
     "prepack": "npm run build",
     "compose": "docker-compose up",

--- a/test/unit/index.spec.ts
+++ b/test/unit/index.spec.ts
@@ -6,7 +6,7 @@ const pluginManager = new PluginManager([feedbackPlugin()]);
 test('Expected contracts are loaded', () => {
 	const contracts = pluginManager.getCards();
 	expect(Object.keys(contracts).includes('typeform-feedback')).toBe(true);
-	expect(Object.keys(contracts).includes('channel-feedback')).toBe(true);
+	expect(Object.keys(contracts).includes('channel-user-feedback')).toBe(true);
 });
 
 test('Expected integrations are loaded', () => {


### PR DESCRIPTION
Revert channel slug back to channel-user-feedback so as to not cause user interruption for those who frequent the channel. Update the query to match both old user-feedback contracts and the new typeform-feedback contracts. Will restrict to typeform-feedback contracts once the type transition is complete.

Change-type: major
Signed-off-by: Josh Bowling <josh@monarci.com>